### PR TITLE
fix: stop Mart giving 0 premier balls

### DIFF
--- a/src/shop.c
+++ b/src/shop.c
@@ -1205,23 +1205,17 @@ static void Task_ReturnToItemListAfterItemPurchase(u8 taskId)
             u32 spaceAvailable = GetFreeSpaceForItemInBag(ITEM_PREMIER_BALL);
             if (spaceAvailable < premierBallsToAdd)
                 premierBallsToAdd = spaceAvailable;
-        }
-        else
-        {
-            premierBallsToAdd = 0;
-        }
 
-        PlaySE(SE_SELECT);
-        AddBagItem(ITEM_PREMIER_BALL, premierBallsToAdd);
-        if (premierBallsToAdd > 0)
-        {
-            ConvertIntToDecimalStringN(gStringVar1, premierBallsToAdd, STR_CONV_MODE_LEFT_ALIGN, MAX_ITEM_DIGITS);
-            BuyMenuDisplayMessage(taskId, (premierBallsToAdd >= 2 ? gText_ThrowInPremierBalls : gText_ThrowInPremierBall), BuyMenuReturnToItemList);
-        }
-        else
-        {
-            BuyMenuReturnToItemList(taskId);
-        }
+             PlaySE(SE_SELECT);
+             AddBagItem(ITEM_PREMIER_BALL, premierBallsToAdd);
+             ConvertIntToDecimalStringN(gStringVar1, premierBallsToAdd, STR_CONV_MODE_LEFT_ALIGN, MAX_ITEM_DIGITS);
+             BuyMenuDisplayMessage(taskId, (premierBallsToAdd >= 2 ? gText_ThrowInPremierBalls : gText_ThrowInPremierBall), BuyMenuReturnToItemList);
+         }
+         else
+         {
+             PlaySE(SE_SELECT);
+             BuyMenuReturnToItemList(taskId);
+         }
     }
 }
 


### PR DESCRIPTION
Previously, if the player bought 1-9 Poké Balls then the Poké Mart would add 0 Premier Balls to their bag as well.