### PR TITLE
Add working Dockerfile to build the rom

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11
+
+WORKDIR /home/
+COPY install-devkitpro-pacman ./install-devkitpro-pacman
+COPY entrypoint.sh ./entrypoint.sh
+
+RUN ["/bin/bash", "-c", "apt update && apt install -y build-essential gcc-arm-none-eabi binutils-arm-none-eabi git vim libpng-dev python3 wget"]
+RUN ["/bin/bash", "-c", "git clone https://github.com/pret/agbcc"]
+RUN ["/bin/bash", "-c","chmod +x ./install-devkitpro-pacman && ./install-devkitpro-pacman"]
+RUN ["dkp-pacman", "-Sy"]
+RUN ["/bin/bash", "-c", "ln -s /proc/self/mounts /etc/mtab && dkp-pacman -S gba-dev --noconfirm"]
+COPY . /home/pokefirered
+RUN ["/bin/bash", "-c", "cd /home/agbcc/ && ./build.sh && ./install.sh ../pokefirered/"]
+
+WORKDIR /home/pokefirered
+
+ENTRYPOINT ["make"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source /etc/profile.d/devkit-env.sh
+
+echo "Building pokemon $1"
+cd /home/pokefirered/ && make $1

--- a/install-devkitpro-pacman
+++ b/install-devkitpro-pacman
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+if ! [ $(id -u) = 0 ]; then
+  echo "Need root privilege to install!"
+  exit 1
+fi
+
+# ensure apt is set up to work with https sources
+apt-get install apt-transport-https
+
+# Store devkitPro gpg key locally if we don't have it already
+if ! [ -f /usr/share/keyring/devkitpro-pub.gpg ]; then
+  mkdir -p /usr/share/keyring/
+  wget -U "dkp apt" -O /usr/share/keyring/devkitpro-pub.gpg https://apt.devkitpro.org/devkitpro-pub.gpg
+fi
+
+# Add the devkitPro apt repository if we don't have it set up already
+if ! [ -f /etc/apt/sources.list.d/devkitpro.list ]; then
+  echo "deb [signed-by=/usr/share/keyring/devkitpro-pub.gpg] https://apt.devkitpro.org stable main" > /etc/apt/sources.list.d/devkitpro.list
+fi
+
+# Finally install devkitPro pacman
+apt-get update
+apt-get install devkitpro-pacman -y


### PR DESCRIPTION
Hello ! This PRs adds a Dockerfile that let the user build the ROM from the get-go without installing any package in itsown computer.
To make it work, first build the dockerfile:
```bash
cd ${pokefirered-expansion-directory}
docker build -t pokefirered:builder .
```
Then, run the container:
```bash
docker run --it --entrypoint bash --name compiler pokefirered:builder make firered_rev1
```
Finally, get the created rom from the container
```
docker cp compiler:/home/pokefirered/pokefirered_rev1.gba . && date
```

